### PR TITLE
feat: add CLI verbose and JSON output modes

### DIFF
--- a/app/cli/src/cli/main.py
+++ b/app/cli/src/cli/main.py
@@ -79,6 +79,9 @@ def configure_output_mode(*, verbose: bool, json_output: bool, output: OutputFie
     elif verbose:
         o3d.utility.set_verbosity_level(o3d.utility.VerbosityLevel.Debug)
         configure_core_logging(stream=sys.stdout, level=logging.INFO)
+    else:
+        o3d.utility.set_verbosity_level(o3d.utility.VerbosityLevel.Info)
+        configure_core_logging(stream=sys.stderr, level=logging.INFO)
 
 
 def print_result(

--- a/app/cli/src/cli/main.py
+++ b/app/cli/src/cli/main.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+import json
+import logging
+import sys
 from enum import StrEnum
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING, Annotated
 
+import numpy as np
+import open3d as o3d
 import typer
 from core.matcher.icp import refine_registration
 from core.matcher.ransac import global_registration
 from core.ply import Ply
+from core.utils.setup_logging import configure_core_logging
 
 if TYPE_CHECKING:
     from core.matcher.type import RegistrationResult
@@ -40,6 +46,52 @@ def format_result(
     if output is None:
         return str(result)
     return str(getattr(result, output.value))
+
+
+def result_to_json(result: RegistrationResult) -> dict[str, object]:
+    """RegistrationResult を JSON と互換なプリミティブ値に変換する."""
+    transformation = np.asarray(result.transformation, dtype=float)
+    correspondence_set = np.asarray(result.correspondence_set, dtype=int)
+    if transformation.shape != (4, 4):
+        msg = "transformation must be a 4x4 matrix"
+        raise ValueError(msg)
+    if correspondence_set.ndim != 2 or correspondence_set.shape[1] != 2:
+        msg = "correspondence_set must be an Nx2 matrix"
+        raise ValueError(msg)
+    return {
+        "fitness": float(result.fitness),
+        "inlier_rmse": float(result.inlier_rmse),
+        "transformation": transformation.tolist(),
+        "correspondence_set": correspondence_set.tolist(),
+    }
+
+
+def configure_output_mode(*, verbose: bool, json_output: bool, output: OutputField | None) -> None:
+    """CLI のログ出力先と Open3D verbosity をオプションに従って設定する."""
+    if json_output and verbose:
+        raise typer.BadParameter("--json and --verbose cannot be used together")
+    if json_output and output is not None:
+        raise typer.BadParameter("--json and --output cannot be used together")
+
+    if json_output:
+        o3d.utility.set_verbosity_level(o3d.utility.VerbosityLevel.Error)
+        configure_core_logging(stream=sys.stderr, level=logging.INFO)
+    elif verbose:
+        o3d.utility.set_verbosity_level(o3d.utility.VerbosityLevel.Debug)
+        configure_core_logging(stream=sys.stdout, level=logging.INFO)
+
+
+def print_result(
+    result: RegistrationResult,
+    *,
+    json_output: bool,
+    output: OutputField | None,
+) -> None:
+    """モードに応じて RegistrationResult を標準出力へ出力する."""
+    if json_output:
+        print(json.dumps(result_to_json(result)))
+        return
+    print(format_result(result, output))
 
 
 @app.command()
@@ -79,12 +131,21 @@ def ransac(
             help="CLIに出力するRegistrationResultのフィールド。未指定時は結果全体をprintする。",
         ),
     ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option(help="core と Open3D の詳細ログを stdout に出力する。"),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="結果を JSON 1行で stdout に出力する。"),
+    ] = False,
 ) -> None:
+    configure_output_mode(verbose=verbose, json_output=json_output, output=output)
     source_ply = Ply(source_path, voxel_size)
     target_ply = Ply(target_path, voxel_size)
 
     rsc_result = global_registration(source_ply, target_ply, voxel_size, ransac_iterations)
-    print(format_result(rsc_result, output))
+    print_result(rsc_result, json_output=json_output, output=output)
 
 
 @app.command()
@@ -124,13 +185,22 @@ def icp(
             help="CLIに出力するRegistrationResultのフィールド。未指定時は結果全体をprintする。",
         ),
     ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option(help="core と Open3D の詳細ログを stdout に出力する。"),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="結果を JSON 1行で stdout に出力する。"),
+    ] = False,
 ) -> None:
+    configure_output_mode(verbose=verbose, json_output=json_output, output=output)
     source_ply = Ply(source_path, voxel_size)
     target_ply = Ply(target_path, voxel_size)
 
     rsc_result = global_registration(source_ply, target_ply, voxel_size, ransac_iterations)
     icp_result = refine_registration(source_ply, target_ply, rsc_result.transformation, voxel_size)
-    print(format_result(icp_result, output))
+    print_result(icp_result, json_output=json_output, output=output)
 
 
 @app.command()
@@ -170,13 +240,22 @@ def matching(
             help="CLIに出力するRegistrationResultのフィールド。未指定時は結果全体をprintする。",
         ),
     ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option(help="core と Open3D の詳細ログを stdout に出力する。"),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="結果を JSON 1行で stdout に出力する。"),
+    ] = False,
 ) -> None:
+    configure_output_mode(verbose=verbose, json_output=json_output, output=output)
     source_ply = Ply(source_path, voxel_size)
     target_ply = Ply(target_path, voxel_size)
 
     rsc_result = global_registration(source_ply, target_ply, voxel_size, ransac_iterations)
     icp_result = refine_registration(source_ply, target_ply, rsc_result.transformation, voxel_size)
-    print(format_result(icp_result, output))
+    print_result(icp_result, json_output=json_output, output=output)
 
 
 if __name__ == "__main__":

--- a/app/core/src/core/utils/setup_logging/__init__.py
+++ b/app/core/src/core/utils/setup_logging/__init__.py
@@ -1,3 +1,3 @@
-from .setup_loggin import setup_logging
+from .setup_loggin import configure_core_logging, setup_logging
 
-__all__ = ["setup_logging"]
+__all__ = ["configure_core_logging", "setup_logging"]

--- a/app/core/src/core/utils/setup_logging/setup_loggin.py
+++ b/app/core/src/core/utils/setup_logging/setup_loggin.py
@@ -51,20 +51,26 @@ def setup_logging(
     """
     logger = logging.getLogger(name)
     logger.setLevel(level)
-    logger.propagate = False
-
-    handlers = [
+    core_handlers = [
         handler
         for handler in logger.handlers
         if getattr(handler, _HANDLER_MARKER, False)
     ]
-    if not handlers:
-        logger.addHandler(_create_handler(stream, level))
-    else:
-        for handler in handlers:
+    if core_handlers:
+        logger.setLevel(level)
+        logger.propagate = False
+        for handler in core_handlers:
             handler.setLevel(level)
             if isinstance(handler, logging.StreamHandler):
                 handler.setStream(stream)
+        return logger
+
+    if logger.hasHandlers():
+        return logger
+
+    logger.setLevel(level)
+    logger.propagate = False
+    logger.addHandler(_create_handler(stream, level))
 
     return logger
 
@@ -82,17 +88,17 @@ def configure_core_logging(*, stream: TextIO, level: int = logging.INFO) -> None
         if not isinstance(value, Logger):
             continue
 
-        value.setLevel(level)
-        value.propagate = False
-        handlers = [
+        core_handlers = [
             handler
             for handler in value.handlers
             if getattr(handler, _HANDLER_MARKER, False)
         ]
-        if not handlers:
-            value.addHandler(_create_handler(stream, level))
+        if not core_handlers:
             continue
-        for handler in handlers:
+
+        value.setLevel(level)
+        value.propagate = False
+        for handler in core_handlers:
             handler.setLevel(level)
             if isinstance(handler, logging.StreamHandler):
                 handler.setStream(stream)

--- a/app/core/src/core/utils/setup_logging/setup_loggin.py
+++ b/app/core/src/core/utils/setup_logging/setup_loggin.py
@@ -8,10 +8,35 @@
 """
 
 import logging
+import sys
 from logging import Logger
+from typing import TextIO
 
 
-def setup_logging(name: str) -> Logger:
+_HANDLER_MARKER = "_core_setup_logging_handler"
+_CORE_LOGGER_NAME = "core"
+
+
+def _create_handler(stream: TextIO, level: int) -> logging.StreamHandler[TextIO]:
+    """core 用の標準フォーマット済みハンドラを生成する."""
+    handler = logging.StreamHandler(stream)
+    setattr(handler, _HANDLER_MARKER, True)
+    handler.setLevel(level)
+    handler.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    return handler
+
+
+def setup_logging(
+    name: str,
+    *,
+    stream: TextIO = sys.stderr,
+    level: int = logging.INFO,
+) -> Logger:
     """指定された名前のロガーを作成・設定して返す.
 
     INFOレベル以上のログをコンソール(stderr)に出力するハンドラを設定する.
@@ -25,20 +50,49 @@ def setup_logging(name: str) -> Logger:
         設定済みのLoggerインスタンス.
     """
     logger = logging.getLogger(name)
-    logger.setLevel(level=logging.INFO)
+    logger.setLevel(level)
+    logger.propagate = False
 
-    # ハンドラの重複追加を防止、モジュールが複数回インポートされた場合など
-
-    if not logger.hasHandlers():
-        handler = logging.StreamHandler()
-        handler.setLevel(logging.INFO)
-
-        formatter = logging.Formatter(
-            fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        handler.setFormatter(formatter)
-
-        logger.addHandler(handler)
+    handlers = [
+        handler
+        for handler in logger.handlers
+        if getattr(handler, _HANDLER_MARKER, False)
+    ]
+    if not handlers:
+        logger.addHandler(_create_handler(stream, level))
+    else:
+        for handler in handlers:
+            handler.setLevel(level)
+            if isinstance(handler, logging.StreamHandler):
+                handler.setStream(stream)
 
     return logger
+
+
+def configure_core_logging(*, stream: TextIO, level: int = logging.INFO) -> None:
+    """初期化済みの core logger を CLI 実行時の出力先へ統一する.
+
+    CLI のオプションはモジュール import 後に評価されるため、既に作成済みの
+    logger もここで再設定する。未初期化の logger は対象にしない。
+    """
+    logger_dict = logging.Logger.manager.loggerDict
+    for name, value in logger_dict.items():
+        if name != _CORE_LOGGER_NAME and not name.startswith(f"{_CORE_LOGGER_NAME}."):
+            continue
+        if not isinstance(value, Logger):
+            continue
+
+        value.setLevel(level)
+        value.propagate = False
+        handlers = [
+            handler
+            for handler in value.handlers
+            if getattr(handler, _HANDLER_MARKER, False)
+        ]
+        if not handlers:
+            value.addHandler(_create_handler(stream, level))
+            continue
+        for handler in handlers:
+            handler.setLevel(level)
+            if isinstance(handler, logging.StreamHandler):
+                handler.setStream(stream)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+ROOT = Path(__file__).parents[1]
+sys.path.insert(0, str(ROOT / "app" / "core" / "src"))
+sys.path.insert(0, str(ROOT / "app" / "cli" / "src"))
+
+from cli.main import OutputField, configure_output_mode, print_result, result_to_json
+
+
+class Result:
+    fitness = 0.95
+    inlier_rmse = 0.0123
+    transformation = np.identity(4)
+    correspondence_set = np.array([[1, 2], [3, 4]])
+
+
+class CliOutputTests(unittest.TestCase):
+    def test_result_to_json_preserves_all_registration_fields(self) -> None:
+        result = result_to_json(Result())
+
+        self.assertEqual(result["fitness"], 0.95)
+        self.assertEqual(result["inlier_rmse"], 0.0123)
+        self.assertEqual(result["transformation"], np.identity(4).tolist())
+        self.assertEqual(result["correspondence_set"], [[1, 2], [3, 4]])
+
+    def test_json_output_is_a_single_parseable_line(self) -> None:
+        stdout = StringIO()
+
+        with redirect_stdout(stdout):
+            print_result(Result(), json_output=True, output=None)
+
+        output = stdout.getvalue()
+        self.assertEqual(output.count("\n"), 1)
+        self.assertEqual(json.loads(output)["correspondence_set"], [[1, 2], [3, 4]])
+
+    def test_json_rejects_output_field(self) -> None:
+        with self.assertRaisesRegex(Exception, "--json and --output"):
+            configure_output_mode(
+                verbose=False,
+                json_output=True,
+                output=OutputField.FITNESS,
+            )
+
+    def test_json_rejects_verbose(self) -> None:
+        with self.assertRaisesRegex(Exception, "--json and --verbose"):
+            configure_output_mode(verbose=True, json_output=True, output=None)
+
+    @patch("cli.main.configure_core_logging")
+    @patch("cli.main.o3d.utility.set_verbosity_level")
+    def test_verbose_configures_debug_logging(self, set_verbosity_level, configure_logging) -> None:
+        configure_output_mode(verbose=True, json_output=False, output=None)
+
+        set_verbosity_level.assert_called_once()
+        configure_logging.assert_called_once_with(stream=sys.stdout, level=20)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(ROOT / "app" / "cli" / "src"))
 from cli.main import (  # noqa: E402
     OutputField,
     configure_output_mode,
+    o3d,
     print_result,
     result_to_json,
 )
@@ -67,3 +68,11 @@ class CliOutputTests(unittest.TestCase):
 
         set_verbosity_level.assert_called_once()
         configure_logging.assert_called_once_with(stream=sys.stdout, level=20)
+
+    @patch("cli.main.configure_core_logging")
+    @patch("cli.main.o3d.utility.set_verbosity_level")
+    def test_normal_mode_resets_default_logging(self, set_verbosity_level, configure_logging) -> None:
+        configure_output_mode(verbose=False, json_output=False, output=None)
+
+        set_verbosity_level.assert_called_once_with(o3d.utility.VerbosityLevel.Info)
+        configure_logging.assert_called_once_with(stream=sys.stderr, level=20)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -14,7 +14,12 @@ ROOT = Path(__file__).parents[1]
 sys.path.insert(0, str(ROOT / "app" / "core" / "src"))
 sys.path.insert(0, str(ROOT / "app" / "cli" / "src"))
 
-from cli.main import OutputField, configure_output_mode, print_result, result_to_json
+from cli.main import (  # noqa: E402
+    OutputField,
+    configure_output_mode,
+    print_result,
+    result_to_json,
+)
 
 
 class Result:

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -17,6 +17,8 @@ class SetupLoggingTests(unittest.TestCase):
         self.logger_name = f"core.tests.setup_logging.{self.id()}"
         self.logger = logging.getLogger(self.logger_name)
         self.logger.handlers.clear()
+        self.logger.setLevel(logging.NOTSET)
+        self.logger.propagate = True
 
     def tearDown(self) -> None:
         self.logger.handlers.clear()
@@ -48,3 +50,28 @@ class SetupLoggingTests(unittest.TestCase):
         logger.info("configured")
 
         self.assertIn("configured", stream.getvalue())
+
+    def test_existing_handler_is_preserved(self) -> None:
+        stream = StringIO()
+        external_handler = logging.StreamHandler(stream)
+        self.logger.addHandler(external_handler)
+
+        logger = setup_logging(self.logger_name)
+        logger.info("configured")
+
+        self.assertEqual(logger.handlers, [external_handler])
+        self.assertTrue(logger.propagate)
+        self.assertIn("configured", stream.getvalue())
+
+    def test_cli_configuration_does_not_change_external_handler(self) -> None:
+        stream = StringIO()
+        external_handler = logging.StreamHandler(stream)
+        self.logger.addHandler(external_handler)
+        setup_logging(self.logger_name)
+
+        configure_core_logging(stream=sys.stdout)
+
+        handler = self.logger.handlers[0]
+        self.assertIsInstance(handler, logging.StreamHandler)
+        assert isinstance(handler, logging.StreamHandler)
+        self.assertIs(handler.stream, stream)

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+sys.path.insert(0, str(ROOT / "app" / "core" / "src"))
+
+from core.utils.setup_logging import configure_core_logging, setup_logging
+
+
+class SetupLoggingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.logger_name = f"core.tests.setup_logging.{self.id()}"
+        self.logger = logging.getLogger(self.logger_name)
+        self.logger.handlers.clear()
+
+    def tearDown(self) -> None:
+        self.logger.handlers.clear()
+
+    def test_default_handler_writes_to_stderr(self) -> None:
+        logger = setup_logging(self.logger_name)
+
+        self.assertEqual(len(logger.handlers), 1)
+        self.assertIsInstance(logger.handlers[0], logging.StreamHandler)
+        self.assertIs(logger.handlers[0].stream, sys.stderr)
+
+    def test_setup_does_not_duplicate_handlers(self) -> None:
+        setup_logging(self.logger_name)
+        logger = setup_logging(self.logger_name)
+
+        self.assertEqual(len(logger.handlers), 1)
+
+    def test_cli_configuration_switches_existing_logger_to_stdout(self) -> None:
+        logger = setup_logging(self.logger_name)
+
+        configure_core_logging(stream=sys.stdout)
+
+        self.assertIs(logger.handlers[0].stream, sys.stdout)
+
+    def test_custom_stream_receives_logs(self) -> None:
+        stream = StringIO()
+        logger = setup_logging(self.logger_name, stream=stream)
+
+        logger.info("configured")
+
+        self.assertIn("configured", stream.getvalue())

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -9,7 +9,7 @@ from pathlib import Path
 ROOT = Path(__file__).parents[1]
 sys.path.insert(0, str(ROOT / "app" / "core" / "src"))
 
-from core.utils.setup_logging import configure_core_logging, setup_logging
+from core.utils.setup_logging import configure_core_logging, setup_logging  # noqa: E402
 
 
 class SetupLoggingTests(unittest.TestCase):


### PR DESCRIPTION
Summary: add verbose and JSON output modes to ransac, icp, and matching; configure core and Open3D logging by output mode; include full registration results in single-line JSON.\n\nValidation: python3 compileall completed; core logging behavior assertion completed. uv and mise are unavailable in this execution environment.